### PR TITLE
Add a 'Pass Through URI' Data Converter to JSON-LD: Issue-1581

### DIFF
--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\jsonld;
 
-use Drupal\Core\Entity\EntityInterface;
-
 /**
  * Converts EntityReferenceField targets.
  */
@@ -12,8 +10,9 @@ class EntityReferenceConverter {
   /**
    * Swaps out an Entity's URI with the value in a field.
    *
-   * @param \Drupal\Core\Entity\EntityInterface $target
-   *   The target of the entity reference field being converted.
+   * @param array|\Drupal\Core\Entity\EntityInterface $target
+   *   Either the target of the entity reference field being converted (JSON-LD module)
+   *   or an array with 'target_id' (RDF module).
    * @param array $arguments
    *   An array of arguments defined in the mapping.
    *   Expected keys are:
@@ -22,8 +21,8 @@ class EntityReferenceConverter {
    * @return mixed
    *   Either the replaced URI string OR the targeted entity if no URI.
    */
-  public static function linkFieldPassthrough(EntityInterface $target, array $arguments) {
-    if (!empty($target->get($arguments['link_field'])->uri)) {
+  public static function linkFieldPassthrough($target, array $arguments) {
+    if (is_a($target, 'Drupal\Core\Entity\FieldableEntityInterface') && !empty($target->get($arguments['link_field'])->uri)) {
       return $target->get($arguments['link_field'])->uri;
     }
     // We don't have a value to pass, so don't bother converting.

--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\jsonld;
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Converts EntityReferenceField targets.
+ */
+class EntityReferenceConverter {
+
+  /**
+   * Swaps out an Entity's URI with the value in a field.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $target
+   *   The target of the entity reference field being converted.
+   * @param array $arguments
+   *   An array of arguments defined in the mapping.
+   *   Expected keys are:
+   *     - link_field: The field used to store the URI we will use.
+   *
+   * @return mixed
+   *   Either the replaced URI string OR the targeted entity if no URI.
+   */
+  public static function linkFieldPassthrough(EntityInterface $target, array $arguments) {
+    if (!empty($target->get($arguments['link_field'])->uri)) {
+      return $target->get($arguments['link_field'])->uri;
+    }
+    // We don't have a value to pass, so don't bother converting.
+    return $target;
+  }
+
+}

--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -11,8 +11,9 @@ class EntityReferenceConverter {
    * Swaps out an Entity's URI with the value in a field.
    *
    * @param array|\Drupal\Core\Entity\EntityInterface $target
-   *   Either the target of the entity reference field being converted (JSON-LD module)
-   *   or an array with 'target_id' (RDF module).
+   *   Either the target of the entity reference field being converted
+   *   (as the JSON-LD module does) or an array with 'target_id'
+   *   (as the RDF module does).
    * @param array $arguments
    *   An array of arguments defined in the mapping.
    *   Expected keys are:

--- a/tests/src/Functional/JsonldContextGeneratorTest.php
+++ b/tests/src/Functional/JsonldContextGeneratorTest.php
@@ -28,6 +28,11 @@ class JsonldContextGeneratorTest extends BrowserTestBase {
   ];
 
   /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
    * Initial setup tasks that for every method method.
    */
   public function setUp() {

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -174,7 +174,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
     ])->save();
 
     $entity_manager = \Drupal::service('entity_type.manager');
-    $link_manager = \Drupal::service('rest.link_manager');
+    $link_manager = \Drupal::service('hal.link_manager');
     $uuid_resolver = \Drupal::service('serializer.entity_resolver.uuid');
     $chain_resolver = new ChainEntityResolver([$uuid_resolver, new TargetIdResolver()]);
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1581

# What does this Pull Request do?

Adds a converter for RDF maps to take the targets of an entity reference field and replace their URI with the value of a Link or Authority Link fields (e.g. the Islandora taxonomy vocabularies or Genre taxonomy vocabulary).

# What's new?

* Changes EntityReferenceItemNormalizer to support the DataConverter to populate '@id' (if '@id' is set as the datatype) OR the '@value'. It also only adds the target entity as another graph if _not_ using the converter.
* Adds EntityReferenceConverter that will replace the target entity with the value of a field as passed with a 'link_field' argument in the RDF mapping.
* Updates the tests so they run without deprecation notices.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
(i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

* Take a site with a node that references some taxonomies where the terms have a link (or authority link) field with a value. E.g. a subject term with an id.loc.gov URI. 
* View the JSON-LD of that node. You will see the field mapped as usual to use the predicate in the RDF mapping where the value is the referenced taxonomy term URI.
* Apply the PR
* Update the RDF mapping so that field uses the new converter. E.g. 
```
  field_subject:
    properties:
      - 'dcterms:subject'
    datatype_callback:
      callable: 'Drupal\jsonld\EntityReferenceConverter::linkFieldPassthrough'
      arguments:
        link_field: 'field_authority_link'
```
* Clear cache
* View the node's JSON-LD again. Instead of seeing the taxonomy term URI you will see the value of the term's link field (e.g. the id.loc.gov URI for a subject).

# Interested parties
@Islandora/8-x-committers
