### PR TITLE
entity reference converter update

### DIFF
--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -32,7 +32,7 @@ class EntityReferenceConverter {
       if ($ent && !empty($ent->get($arguments['link_field'])->uri)) {
         return $ent->get($arguments['link_field'])->uri;
       }
-      else if ($ent) {
+      elseif ($ent) {
         return $ent->get('name')->value;
       }
     }

--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -29,10 +29,10 @@ class EntityReferenceConverter {
 
     if (is_array($target) && array_key_exists('target_id', $target)) {
       $ent = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($target['target_id']);
-      if (!empty($ent->get($arguments['link_field'])->uri)) {
+      if ($ent && !empty($ent->get($arguments['link_field'])->uri)) {
         return $ent->get($arguments['link_field'])->uri;
       }
-      else {
+      else if ($ent) {
         return $ent->get('name')->value;
       }
     }

--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -26,6 +26,16 @@ class EntityReferenceConverter {
     if (is_a($target, 'Drupal\Core\Entity\FieldableEntityInterface') && !empty($target->get($arguments['link_field'])->uri)) {
       return $target->get($arguments['link_field'])->uri;
     }
+
+    if (is_array($target) && array_key_exists('target_id', $target)) {
+      $ent = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($target['target_id']);
+      if (!empty($ent->get($arguments['link_field'])->uri)) {
+        return $ent->get($arguments['link_field'])->uri;
+      }
+      else {
+        return $ent->get('name')->value;
+      }
+    }
     // We don't have a value to pass, so don't bother converting.
     return $target;
   }


### PR DESCRIPTION

**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1773)


# What does this Pull Request do?
updates the entity reference converter which may be broken?

# What's new?
* adds handling for receiving an array of the target_id of a taxonomy term instead of a FieldableEntityInterface object

# How should this be tested?
* spin up a new islandora site with the playbook or ISLE (that has islandora defaults enabled)
* create objects (either manually or through some kind of migration)
* update the rdf mapping for a taxonomy reference field of your choice (ie. subject, resource type, genre, etc with the EntityReferenceConverter plugin like so:
```
field_subject:
    properties:
      - 'dcterms:subject'
    datatype_callback:
      callable: 'Drupal\jsonld\EntityReferenceConverter::linkFieldPassthrough'
      arguments:
        link_field: 'field_authority_link'
```
* populate some field with a taxonomy term reference (ie. subject, resource type, genre, etc)
* view the OAI feed (by default at http://localhost:8000/oai/request?verb=ListRecords&metadataPrefix=oai_dc)
* see an empty element for the value you populated, such as `<dc:type />`
* pull down this PR
* cache rebuild, maybe even rebuild the OAI
* view the oai feed again
* see the value of the term being populated (if it had no URI, or the URI if it had one)

# Interested parties
@Islandora/8-x-committers 
maybe @seth-shaw-unlv ?
