### PR TITLE
Make rdf namespaces configurable (Issue 1520)

### DIFF
--- a/config/schema/jsonld.schema.yml
+++ b/config/schema/jsonld.schema.yml
@@ -5,3 +5,15 @@ jsonld.settings:
     remove_jsonld_format:
       type: boolean 
       label: 'If checked, ?_format=jsonld will be stripped from the end of urls in JSONLD'
+    rdf_namespaces:
+        type: sequence
+        label: 'RDF Namespaces'
+        sequence:
+            type: mapping
+            mapping:
+                prefix: 
+                    type: string
+                    label: 'RDF Prefix'
+                namespace:
+                    type: string
+                    label: 'Fully Qualified RDF Namespace'

--- a/jsonld.module
+++ b/jsonld.module
@@ -22,6 +22,23 @@ function jsonld_help($route_name, RouteMatchInterface $route_match) {
 }
 
 /**
+ * Implements hook_rdf_namespaces().
+ */
+function jsonld_rdf_namespaces() {
+  $config = \Drupal::config('jsonld.settings');
+  $namespace_config = $config->get('rdf_namespaces');
+  if (!is_array($namespace_config)) {
+    // No namespaces have been configured, return empty.
+    return [];
+  }
+  $namespaces = [];
+  foreach ($namespace_config as $namespace) {
+    $namespaces[$namespace['prefix']] = $namespace['namespace'];
+  }
+  return $namespaces;
+}
+
+/**
  * Implements hook_jsonld_field_mappings().
  */
 function jsonld_jsonld_field_mappings() {

--- a/src/Form/JsonLdSettingsForm.php
+++ b/src/Form/JsonLdSettingsForm.php
@@ -15,6 +15,7 @@ class JsonLdSettingsForm extends ConfigFormBase {
   const CONFIG_NAME = 'jsonld.settings';
 
   const REMOVE_JSONLD_FORMAT = 'remove_jsonld_format';
+  const RDF_NAMESPACES = 'rdf_namespaces';
 
   /**
    * {@inheritdoc}
@@ -45,7 +46,40 @@ class JsonLdSettingsForm extends ConfigFormBase {
         '#default_value' => $config->get(self::REMOVE_JSONLD_FORMAT) ? $config->get(self::REMOVE_JSONLD_FORMAT) : FALSE,
       ],
     ];
+
+    $rdf_namespaces = '';
+    foreach ($config->get('rdf_namespaces') as $namespace) {
+      $rdf_namespaces .= $namespace['prefix'] . '|' . $namespace['namespace'] . "\n";
+    }
+    $form[self::RDF_NAMESPACES] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('RDF Namespaces'),
+      '#rows' => 10,
+      '#default_value' => $rdf_namespaces,
+    ];
+
     return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Validate RDF Namespaces.
+    foreach (preg_split("/[\r\n]+/", $form_state->getValue(self::RDF_NAMESPACES)) as $line) {
+      if (empty($line)) {
+        continue;
+      }
+      $namespace = explode("|", trim($line));
+      if (empty($namespace[0]) || empty($namespace[1])) {
+        $form_state->setErrorByName(
+          self::RDF_NAMESPACES,
+          $this->t("RDF Namespace form is malformed on line '@line'",
+            ['@line' => trim($line)]
+          )
+        );
+      }
+    }
   }
 
   /**
@@ -53,7 +87,24 @@ class JsonLdSettingsForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = $this->configFactory->getEditable(self::CONFIG_NAME);
-    $config->set(self::REMOVE_JSONLD_FORMAT, $form_state->getValue(self::REMOVE_JSONLD_FORMAT))
+
+    $namespaces_array = [];
+    foreach (preg_split("/[\r\n]+/", $form_state->getValue(self::RDF_NAMESPACES)) as $line) {
+      if (empty($line)) {
+        continue;
+      }
+      $namespace = explode("|", trim($line));
+      if (!empty($namespace[0]) && !empty($namespace[1])) {
+        $namespaces_array[] = [
+          'prefix' => trim($namespace[0]),
+          'namespace' => trim($namespace[1]),
+        ];
+      }
+    }
+
+    $config
+      ->set(self::REMOVE_JSONLD_FORMAT, $form_state->getValue(self::REMOVE_JSONLD_FORMAT))
+      ->set(self::RDF_NAMESPACES, $namespaces_array)
       ->save();
     parent::submitForm($form, $form_state);
   }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1520

Supersedes https://github.com/Islandora/islandora/pull/831

# What does this Pull Request do?

Enables adding RDF namespaces in config.

# What's new?

* Added rdf_namespace hook to load namespaces from config.
* Updated schema to add rdf_namespaces
* Updated jsonld settings form to update rdf_namespaces config

# How should this be tested?

* Create some records and make sure the JSON-LD looks fine
* Apply this PR and the related islandora PR (https://github.com/Islandora/islandora/pull/832)
* Run drupal updates (`drush updb -y`)
* Clear cache
* Make sure the JSON-LD looks the same
* Go to the core settings form ('/admin/config/search/jsonld') and change one of the namespaces used in the JSON-LD you tested.
* Clear cache again
* View the JSON-LD and see the modified namespace in use.

# Additional Notes:

Reusing a namespaces hardcoded by other modules in their namespace hooks will cause the site to WSOD. As such, the form will not allow you to add a prefix added by another module. Modifying the config by config export/import should be done at your own risk.

# Interested parties
@Islandora/8-x-committers