### PR TITLE
Issue 1806 - exploding colons.

### DIFF
--- a/src/Form/JsonLdSettingsForm.php
+++ b/src/Form/JsonLdSettingsForm.php
@@ -57,6 +57,7 @@ class JsonLdSettingsForm extends ConfigFormBase {
       $rdf_namespaces .= $namespace['prefix'] . '|' . $namespace['namespace'] . "\n";
     }
     $mapping_string = '';
+    ksort($mappings_from_hook);
     foreach ($mappings_from_hook as $pref => $nspace) {
       $mapping_string .= "$pref|$nspace \n";
     }

--- a/src/Form/JsonLdSettingsForm.php
+++ b/src/Form/JsonLdSettingsForm.php
@@ -15,6 +15,7 @@ class JsonLdSettingsForm extends ConfigFormBase {
   const CONFIG_NAME = 'jsonld.settings';
 
   const REMOVE_JSONLD_FORMAT = 'remove_jsonld_format';
+
   const RDF_NAMESPACES = 'rdf_namespaces';
 
   /**
@@ -38,6 +39,11 @@ class JsonLdSettingsForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(self::CONFIG_NAME);
+    $mappings_from_hook = rdf_get_namespaces();
+    $mapping_string = '';
+    foreach ($mappings_from_hook as $pref => $nspace) {
+      $mapping_string .= "$pref|$nspace \n";
+    }
     $form = [
       self::REMOVE_JSONLD_FORMAT => [
         '#type' => 'checkbox',
@@ -53,9 +59,17 @@ class JsonLdSettingsForm extends ConfigFormBase {
     }
     $form[self::RDF_NAMESPACES] = [
       '#type' => 'textarea',
-      '#title' => $this->t('RDF Namespaces'),
+      '#title' => $this->t('Additional RDF Namespaces'),
       '#rows' => 10,
       '#default_value' => $rdf_namespaces,
+      '#description' => $this->t("Enter pipe-separated prefixes and namespaces e.g.<br /><strong>dcterms|http://purl.org/dc/terms/</strong>"),
+    ];
+    $form['existing'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Existing RDF Namespaces from modules'),
+      '#rows' => count($mappings_from_hook),
+      '#value' => $mapping_string,
+      '#attributes' => ['readonly' => 'readonly'],
     ];
 
     return parent::buildForm($form, $form_state);

--- a/src/Form/JsonLdSettingsForm.php
+++ b/src/Form/JsonLdSettingsForm.php
@@ -40,10 +40,6 @@ class JsonLdSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(self::CONFIG_NAME);
     $mappings_from_hook = rdf_get_namespaces();
-    $mapping_string = '';
-    foreach ($mappings_from_hook as $pref => $nspace) {
-      $mapping_string .= "$pref|$nspace \n";
-    }
     $form = [
       self::REMOVE_JSONLD_FORMAT => [
         '#type' => 'checkbox',
@@ -55,7 +51,14 @@ class JsonLdSettingsForm extends ConfigFormBase {
 
     $rdf_namespaces = '';
     foreach ($config->get('rdf_namespaces') as $namespace) {
+      if (isset($mappings_from_hook[$namespace['prefix']])) {
+        unset($mappings_from_hook[$namespace['prefix']]);
+      }
       $rdf_namespaces .= $namespace['prefix'] . '|' . $namespace['namespace'] . "\n";
+    }
+    $mapping_string = '';
+    foreach ($mappings_from_hook as $pref => $nspace) {
+      $mapping_string .= "$pref|$nspace \n";
     }
     $form[self::RDF_NAMESPACES] = [
       '#type' => 'textarea',

--- a/src/Normalizer/NormalizerBase.php
+++ b/src/Normalizer/NormalizerBase.php
@@ -57,7 +57,7 @@ abstract class NormalizerBase extends SerializationNormalizerBase implements Den
    */
   public static function escapePrefix($predicate, array $namespaces) {
 
-    $exploded = explode(":", $predicate);
+    $exploded = explode(":", $predicate, 2);
     if (!isset($namespaces[$exploded[0]])) {
       return $predicate;
     }


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1806)

# What does this Pull Request do?

Not so much a one-line as a one-character change to make predicates explode on the first colon only.
# What's new?
As well as addressing this issue I broke the rules a bit here by throwing a sort function in to make the Settings form more readable. (It relates back to yesterday's issue with adding in-line documentation; It seemed like overkill to have an entire PR just to see that the configs were sorted alphabetically)

# How should this be tested?
Add properties: with a colon in it to an rdf config file.
```
  field_myfield:
    properties:
      - 'wikidata:Property:P7535'
```
Save an object with this field defined with an entered value and see if it shows up when viewing the json ld.  _The previous example will only work if you have registered wikidata as a prefix - it's meant to serve as an example only._


# Interested parties
Tag @seth-shaw-unlv @dannylamb 