### PR TITLE
Merge and deduplicate entity references so we don't get invalid Json-ld

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ["7.3", "7.4"]
-        drupal-version: ["8.9.11", "9.1.5"]
+        php-versions: ["7.4", "8.0", "8.1"]
+        drupal-version: ["9.3.x", "9.4.x-dev"]
 
     services:
       mysql:

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
             "role": "Maintainer"
         }
     ],
+    "require" : {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "phpunit/phpunit": "^8",
         "squizlabs/php_codesniffer": "^3",

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -170,8 +170,8 @@ class ContentEntityNormalizer extends NormalizerBase {
             $normalized_property,
           ]
         );
-        // Deduplicate the @type elements.
-        $normalized = self::deduplicateTypes($normalized);
+        // Deduplicate the @type elements and arrays of entity references.
+        $normalized = self::deduplicateTypesAndReferences($normalized);
       }
     }
     // Clean up @graph if this is the top-level entity

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\jsonld\Normalizer;
 
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\hal\LinkManager\LinkManagerInterface;
@@ -163,7 +164,14 @@ class ContentEntityNormalizer extends NormalizerBase {
         // but the interface (typehint) does not.
         // We could check if serializer implements normalizer interface
         // to avoid any possible errors in case someone swaps serializer.
-        $normalized = array_merge_recursive($normalized, $normalized_property);
+        $normalized = NestedArray::mergeDeepArray(
+          [
+            $normalized,
+            $normalized_property,
+          ]
+        );
+        // Deduplicate the @type elements.
+        $normalized = self::deduplicateTypes($normalized);
       }
     }
     // Clean up @graph if this is the top-level entity

--- a/src/Normalizer/NormalizerBase.php
+++ b/src/Normalizer/NormalizerBase.php
@@ -64,4 +64,26 @@ abstract class NormalizerBase extends SerializationNormalizerBase implements Den
     return $namespaces[$exploded[0]] . $exploded[1];
   }
 
+  /**
+   * Deduplicate lists of @types.
+   *
+   * @param array $array
+   *   The array to deduplicate.
+   *
+   * @return array
+   *   The deduplicated array.
+   */
+  protected static function deduplicateTypes(array $array): array {
+    if (isset($array['@graph'])) {
+      // Should only be run on a top level Jsonld array.
+      foreach ($array['@graph'] as $key => $value) {
+        if (isset($array['@graph'][$key]['@type']) && is_array($array['@graph'][$key]['@type'])) {
+          // Deduplicate @types
+          $array['@graph'][$key]['@type'] = array_unique($array['@graph'][$key]['@type']);
+        }
+      }
+    }
+    return $array;
+  }
+
 }

--- a/src/Normalizer/NormalizerBase.php
+++ b/src/Normalizer/NormalizerBase.php
@@ -65,7 +65,7 @@ abstract class NormalizerBase extends SerializationNormalizerBase implements Den
   }
 
   /**
-   * Deduplicate lists of @types.
+   * Deduplicate lists of @types and predicate to entity references.
    *
    * @param array $array
    *   The array to deduplicate.
@@ -73,17 +73,45 @@ abstract class NormalizerBase extends SerializationNormalizerBase implements Den
    * @return array
    *   The deduplicated array.
    */
-  protected static function deduplicateTypes(array $array): array {
+  protected static function deduplicateTypesAndReferences(array $array): array {
     if (isset($array['@graph'])) {
       // Should only be run on a top level Jsonld array.
-      foreach ($array['@graph'] as $key => $value) {
-        if (isset($array['@graph'][$key]['@type']) && is_array($array['@graph'][$key]['@type'])) {
-          // Deduplicate @types
-          $array['@graph'][$key]['@type'] = array_unique($array['@graph'][$key]['@type']);
+      foreach ($array['@graph'] as $object_key => $object_value) {
+        foreach ($object_value as $key => $values) {
+          if ($key == '@type' && is_array($values)) {
+            $array['@graph'][$object_key]['@type'] = array_unique($values);
+          }
+          elseif ($key != '@id' && is_array($array['@graph'][$object_key][$key])
+            && count($array['@graph'][$object_key][$key]) > 1) {
+            $array['@graph'][$object_key][$key] = self::deduplicateArrayOfIds($array['@graph'][$object_key][$key]);
+          }
         }
       }
     }
     return $array;
+  }
+
+  /**
+   * Deduplicate multi-dimensional array based on the `@id` value.
+   *
+   * @param array $array
+   *   The multi-dimensional array.
+   *
+   * @return array
+   *   The deduplicated multi-dimensional array.
+   */
+  private static function deduplicateArrayOfIds(array $array): array {
+    $temp_array = [];
+    if (!isset($array[0]['@id'])) {
+      // No @id key, so just return the original array.
+      return $array;
+    }
+    foreach ($array as $val) {
+      if (array_search($val['@id'], array_column($temp_array, '@id')) === FALSE) {
+        $temp_array[] = $val;
+      }
+    }
+    return $temp_array;
   }
 
 }

--- a/tests/src/Kernel/JsonldContextGeneratorTest.php
+++ b/tests/src/Kernel/JsonldContextGeneratorTest.php
@@ -63,7 +63,7 @@ class JsonldContextGeneratorTest extends JsonldKernelTestBase {
     ];
 
     // Save bundle mapping config.
-    $rdfMapping = rdf_get_mapping('entity_test', 'rdf_source')
+    rdf_get_mapping('entity_test', 'rdf_source')
       ->setBundleMapping(['types' => $types])
       ->setFieldMapping('created', $mapping)
       ->save();

--- a/tests/src/Kernel/JsonldHookTest.php
+++ b/tests/src/Kernel/JsonldHookTest.php
@@ -37,7 +37,7 @@ class JsonldHookTest extends JsonldKernelTestBase {
    */
   public function testAlterNormalizedJsonld() {
 
-    list($entity, $expected) = $this->generateTestEntity();
+    list($entity, $expected) = JsonldTestEntityGenerator::create()->generateNewEntity();
     $expected['@graph'][] = [
       "@id" => "json_alter_normalize_hooks",
       "http://purl.org/dc/elements/1.1/title" => "The hook is tested.",

--- a/tests/src/Kernel/JsonldTestEntityGenerator.php
+++ b/tests/src/Kernel/JsonldTestEntityGenerator.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Drupal\Tests\jsonld\Kernel;
+
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\Tests\RandomGeneratorTrait;
+use Drupal\user\Entity\User;
+
+/**
+ * Class to allow modification of RDF mapping before generating the entity.
+ */
+class JsonldTestEntityGenerator {
+
+  use RandomGeneratorTrait;
+
+  /**
+   * The user used in the the test object.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  private $user;
+
+  /**
+   * The first test entity referenced in the test object.
+   *
+   * @var \Drupal\entity_test\Entity\EntityTest
+   */
+  private $referrableEntity1;
+
+  /**
+   * The second test entity referenced in the test object.
+   *
+   * @var \Drupal\entity_test\Entity\EntityTest
+   */
+  private $referrableEntity2;
+
+  /**
+   * Constants for swapping around predicates.
+   */
+  private const DCTERMS_URL = "http://purl.org/dc/terms/";
+
+  private const DCTERMS_PUBLISHER = self::DCTERMS_URL . "publisher";
+
+  private const DCTERMS_REFERENCES = self::DCTERMS_URL . "references";
+
+  /**
+   * The predicate used for the first referenced entity.
+   *
+   * @var string
+   */
+  private $referableEntity1Predicate = self::DCTERMS_REFERENCES;
+
+  /**
+   * The predicate used for the second referenced entity.
+   *
+   * @var string
+   */
+  private $referrableEntity2Predicate = self::DCTERMS_PUBLISHER;
+
+  /**
+   * Basic constructor.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function __construct() {
+    $this->referrableEntity1 = $this->generateReferrableEntity();
+    $this->referrableEntity1->save();
+
+    $this->referrableEntity2 = $this->generateReferrableEntity();
+    $this->referrableEntity2->save();
+
+    $this->user = User::create([
+      'name' => $this->randomMachineName(),
+      'langcode' => 'en',
+    ]);
+    $this->user->save();
+
+    rdf_get_mapping('entity_test', 'entity_test')->setBundleMapping(
+      [
+        'types' => [
+          "schema:ImageObject",
+        ],
+      ])->setFieldMapping('field_test_text', [
+        'properties' => ['dc:description'],
+      ])->setFieldMapping('user_id', [
+        'properties' => ['schema:author'],
+      ])->setFieldMapping('modified', [
+        'properties' => ['schema:dateModified'],
+        'datatype' => 'xsd:dateTime',
+      ])->save();
+  }
+
+  /**
+   * Static construction method.
+   *
+   * @return \Drupal\Tests\jsonld\Kernel\JsonldTestEntityGenerator
+   *   A new test entity generator.
+   */
+  public static function create() {
+    return new JsonldTestEntityGenerator();
+  }
+
+  /**
+   * Create a new random entity.
+   *
+   * @return \Drupal\entity_test\Entity\EntityTest
+   *   The new test entity.
+   */
+  private function generateReferrableEntity(): EntityTest {
+    $target_entity = EntityTest::create([
+      'name' => $this->randomMachineName(),
+      'langcode' => 'en',
+      'field_test_entity_reference' => NULL,
+    ]);
+    $target_entity->getFieldDefinition('created')->setTranslatable(FALSE);
+    $target_entity->getFieldDefinition('user_id')->setTranslatable(FALSE);
+    return $target_entity;
+  }
+
+  /**
+   * Make both reference fields point to the same entity.
+   *
+   * @return \Drupal\Tests\jsonld\Kernel\JsonldTestEntityGenerator
+   *   This test entity generator.
+   */
+  public function makeDuplicateReference(): JsonldTestEntityGenerator {
+    $this->referrableEntity2 = $this->referrableEntity1;
+    return $this;
+  }
+
+  /**
+   * Make reference field 2 use the same RDF predicate as reference field 1.
+   *
+   * @return \Drupal\Tests\jsonld\Kernel\JsonldTestEntityGenerator
+   *   This test entity generator.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   *   Error altering the RDF mapping.
+   */
+  public function makeDuplicateReferenceMapping(): JsonldTestEntityGenerator {
+    rdf_get_mapping('entity_test', 'entity_test')
+      ->setFieldMapping('field_test_entity_reference2', [
+        'properties' => ['dc:references'],
+        'datatype' => 'xsd:nonNegativeInteger',
+      ]
+    )->save();
+    $this->referrableEntity2Predicate = $this->referableEntity1Predicate;
+    return $this;
+  }
+
+  /**
+   * Generate the entity and expected Json-ld array.
+   *
+   * @return array
+   *   Array of [ entity , expected jsonld array ].
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   *   Error saving the entity.
+   */
+  public function generateNewEntity(): array {
+    $dt = new \DateTime(NULL, new \DateTimeZone('UTC'));
+    $created = $dt->format("U");
+    $created_iso = $dt->format(\DateTime::W3C);
+    // Create an entity.
+    $values = [
+      'langcode' => 'en',
+      'name' => $this->randomMachineName(),
+      'type' => 'entity_test',
+      'bundle' => 'entity_test',
+      'user_id' => $this->user->id(),
+      'created' => [
+        'value' => $created,
+      ],
+      'field_test_text' => [
+        'value' => $this->randomMachineName(),
+        'format' => 'full_html',
+      ],
+      'field_test_entity_reference' => [
+        'target_id' => $this->referrableEntity1->id(),
+      ],
+      'field_test_entity_reference2' => [
+        'target_id' => $this->referrableEntity2->id(),
+      ],
+    ];
+
+    $entity = EntityTest::create($values);
+    $entity->save();
+
+    $id = "http://localhost/entity_test/" . $entity->id() . "?_format=jsonld";
+    $target_id = "http://localhost/entity_test/" . $this->referrableEntity1->id() . "?_format=jsonld";
+    $target_id_2 = "http://localhost/entity_test/" . $this->referrableEntity2->id() . "?_format=jsonld";
+    $user_id = "http://localhost/user/" . $this->user->id() . "?_format=jsonld";
+
+    $expected = [
+      "@graph" => [
+        [
+          "@id" => $id,
+          "@type" => [
+            'http://schema.org/ImageObject',
+          ],
+          "http://purl.org/dc/terms/references" => [
+            [
+              "@id" => $target_id,
+            ],
+          ],
+          "http://purl.org/dc/terms/publisher" => [
+            [
+              "@id" => $target_id_2,
+            ],
+          ],
+          "http://purl.org/dc/terms/description" => [
+            [
+              "@value" => $values['field_test_text']['value'],
+              "@language" => "en",
+            ],
+          ],
+          "http://purl.org/dc/terms/title" => [
+            [
+              "@language" => "en",
+              "@value" => $values['name'],
+            ],
+          ],
+          "http://schema.org/author" => [
+            [
+              "@id" => $user_id,
+            ],
+          ],
+          "http://schema.org/dateCreated" => [
+            [
+              "@type" => "http://www.w3.org/2001/XMLSchema#dateTime",
+              "@value" => $created_iso,
+            ],
+          ],
+        ],
+        [
+          "@id" => $user_id,
+          "@type" => "http://localhost/rest/type/user/user",
+        ],
+        [
+          "@id" => $target_id,
+          "@type" => [
+            "http://schema.org/ImageObject",
+          ],
+        ],
+      ],
+    ];
+    // If we mapped two entities to the same predicate we need to merge them.
+    if ($this->referableEntity1Predicate == $this->referrableEntity2Predicate) {
+      $expected['@graph'][0][self::DCTERMS_REFERENCES] = array_merge(
+        $expected['@graph'][0][self::DCTERMS_REFERENCES],
+        $expected['@graph'][0][self::DCTERMS_PUBLISHER]
+      );
+      unset($expected['@graph'][0][self::DCTERMS_PUBLISHER]);
+    }
+    // If the 2 referenced entities are different both need to have an entry.
+    if ($target_id !== $target_id_2) {
+      $expected['@graph'][] = [
+        "@id" => $target_id_2,
+        "@type" => [
+          "http://schema.org/ImageObject",
+        ],
+      ];
+    }
+
+    return [$entity, $expected];
+  }
+
+}

--- a/tests/src/Kernel/JsonldTestEntityGenerator.php
+++ b/tests/src/Kernel/JsonldTestEntityGenerator.php
@@ -244,12 +244,15 @@ class JsonldTestEntityGenerator {
         ],
       ],
     ];
-    // If we mapped two entities to the same predicate we need to merge them.
+    // If we mapped two entities to the same predicate we remove one.
     if ($this->referableEntity1Predicate == $this->referrableEntity2Predicate) {
-      $expected['@graph'][0][self::DCTERMS_REFERENCES] = array_merge(
-        $expected['@graph'][0][self::DCTERMS_REFERENCES],
-        $expected['@graph'][0][self::DCTERMS_PUBLISHER]
-      );
+      if ($this->referrableEntity1 !== $this->referrableEntity2) {
+        // If there are two different entities referred to, then merge them.
+        $expected['@graph'][0][self::DCTERMS_REFERENCES] = array_merge(
+          $expected['@graph'][0][self::DCTERMS_REFERENCES],
+          $expected['@graph'][0][self::DCTERMS_PUBLISHER]
+        );
+      }
       unset($expected['@graph'][0][self::DCTERMS_PUBLISHER]);
     }
     // If the 2 referenced entities are different both need to have an entry.

--- a/tests/src/Kernel/Normalizer/JsonldContentEntityNormalizerTest.php
+++ b/tests/src/Kernel/Normalizer/JsonldContentEntityNormalizerTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\jsonld\Kernel\Normalizer;
 
 use Drupal\Tests\jsonld\Kernel\JsonldKernelTestBase;
+use Drupal\Tests\jsonld\Kernel\JsonldTestEntityGenerator;
 
 /**
  * Tests the JSON-LD Normalizer.
@@ -32,7 +33,7 @@ class JsonldContentEntityNormalizerTest extends JsonldKernelTestBase {
    */
   public function testSimpleNormalizeJsonld() {
 
-    list($entity, $expected) = $this->generateTestEntity();
+    list($entity, $expected) = JsonldTestEntityGenerator::create()->generateNewEntity();
 
     $normalized = $this->serializer->normalize($entity, $this->format);
     $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
@@ -51,7 +52,7 @@ class JsonldContentEntityNormalizerTest extends JsonldKernelTestBase {
    */
   public function testLocalizedNormalizeJsonld() {
 
-    list($entity, $expected) = $this->generateTestEntity();
+    list($entity, $expected) = JsonldTestEntityGenerator::create()->generateNewEntity();
 
     $existing_entity_values = $entity->toArray();
     $target_entity_tl_id = $existing_entity_values['field_test_entity_reference'][0]['target_id'];
@@ -88,6 +89,47 @@ class JsonldContentEntityNormalizerTest extends JsonldKernelTestBase {
 
     $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
 
+  }
+
+  /**
+   * Where multiple referenced entities are tied to the same rdf mapping.
+   */
+  public function testDeduplicateEntityReferenceMappings(): void {
+
+    list($entity, $expected) = JsonldTestEntityGenerator::create()->makeDuplicateReferenceMapping()->generateNewEntity();
+
+    $normalized = $this->serializer->normalize($entity, $this->format);
+
+    $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
+  }
+
+  /**
+   * Test where multiple fields rdf mapping is referencing the same entity.
+   */
+  public function testDeduplicateEntityReferenceIds(): void {
+
+    list($entity, $expected) = JsonldTestEntityGenerator::create()->makeDuplicateReference()->generateNewEntity();
+
+    $normalized = $this->serializer->normalize($entity, $this->format);
+
+    $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
+  }
+
+  /**
+   * Test where multiple fields are.
+   *
+   *  - are referencing the same entity.
+   *  - sharing the same RDF mapping.
+   */
+  public function testDuplicateEntityReferenceAndMappings(): void {
+    list($entity, $expected) = JsonldTestEntityGenerator::create()->makeDuplicateReference()->makeDuplicateReferenceMapping()
+      ->generateNewEntity();
+
+    $normalized = $this->serializer->normalize($entity, $this->format);
+
+    // var_dump($expected);
+    // var_dump($normalized);
+    $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
   }
 
 }

--- a/tests/src/Kernel/Normalizer/JsonldContentEntityNormalizerTest.php
+++ b/tests/src/Kernel/Normalizer/JsonldContentEntityNormalizerTest.php
@@ -127,8 +127,6 @@ class JsonldContentEntityNormalizerTest extends JsonldKernelTestBase {
 
     $normalized = $this->serializer->normalize($entity, $this->format);
 
-    // var_dump($expected);
-    // var_dump($normalized);
     $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
   }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2082

# What does this Pull Request do?

Alters the Normalizer to do a deep merge of the individually serialized properties JSON-LD back into the main graph, it also does _some_ de-duplication of type arrays and arrays of entity IDs.

# What's new?

* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
(i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

If you create two fields that share a taxonomy vocabulary and also use the same RDF predicate. If you create a new resource and use the exact same taxonomy term for both of these fields you end up with incorrect JSON-LD (viewable by appending `?_format=jsonld` to the end of the node URL). 

Pull in this PR and reload (having cleared the cache) the JSON-LD serialization and see it has been fixed.

It also modifies the testing matrix to update PHP versions and Drupal versions.

# Additional Notes:
This does not do full deduplication of more complex types (ie. text values with language strings).

# Interested parties
@Islandora/8-x-committers
