### PR TITLE
preserve arrays without @id

### DIFF
--- a/src/Normalizer/NormalizerBase.php
+++ b/src/Normalizer/NormalizerBase.php
@@ -102,12 +102,8 @@ abstract class NormalizerBase extends SerializationNormalizerBase implements Den
    */
   private static function deduplicateArrayOfIds(array $array): array {
     $temp_array = [];
-    if (!isset($array[0]['@id'])) {
-      // No @id key, so just return the original array.
-      return $array;
-    }
     foreach ($array as $val) {
-      if (array_search($val['@id'], array_column($temp_array, '@id')) === FALSE) {
+      if (!array_key_exists('@id', $val) || array_search($val['@id'], array_column($temp_array, '@id')) === FALSE) {
         $temp_array[] = $val;
       }
     }


### PR DESCRIPTION
**GitHub Issue**: #61 

# What does this Pull Request do?

Removes assumption that if the first array has '@id' then they all do. Now, just copy the value or check for deduplication if it has an '@id'.

# What's new?
A in-depth description of the changes made by this PR. Technical details and 
possible side effects.

* Changes NormalizerBase::deduplicateArrayOfIds to _not_ just copy if the first one doesn't have '@id' but to also simply copy the array part if there isn't an '@id'.
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
(i.e. Regeneration activity, etc.)? Clear cache.
* Could this change impact execution of existing code? Stop generating jsonld errors about missing '@id' keys.

# How should this be tested?

Not sure. Never got around to figuring out exactly what combination of metadata generated this error.

# Interested parties
@Islandora/committers, esp. @whikloj 
