### PR TITLE
Use external hal

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -19,10 +19,19 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         php-versions: ["7.4", "8.0", "8.1"]
-        drupal-version: ["9.3.x", "9.4.x-dev"]
+        experimental: [false]
+        drupal-version: ["9.4.0", "9.4.1", "9.5.x-dev"]
+        include:
+          - php-versions: "8.0"
+            experimental: true
+            drupal-version: "10.x-dev"
+          - php-versions: "8.1"
+            experimental: true
+            drupal-version: "10.x-dev"
 
     services:
       mysql:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         }
     ],
     "require" : {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "drupal/hal-hal": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",

--- a/jsonld.info.yml
+++ b/jsonld.info.yml
@@ -4,6 +4,6 @@ description: 'Serializes entities to JSON-LD / LDP for the Islandora Project'
 package: Web services
 core_version_requirement: ">=9.4"
 dependencies:
-  - drupal:hal-hal
+  - drupal:hal
   - drupal:serialization
   - drupal:rdf

--- a/jsonld.info.yml
+++ b/jsonld.info.yml
@@ -2,8 +2,8 @@ name: 'JSON-LD'
 type: module
 description: 'Serializes entities to JSON-LD / LDP for the Islandora Project'
 package: Web services
-core_version_requirement: ^9
+core_version_requirement: ">=9.4"
 dependencies:
-  - hal
-  - serialization
-  - rdf
+  - drupal:hal-hal
+  - drupal:serialization
+  - drupal:rdf


### PR DESCRIPTION
**GitHub Issue**: #63 

# What does this Pull Request do?

Includes the contrib hal module and moves the requirement for this module to Drupal 9.4 or higher.

# What's new?
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? yes
* Does this change require any other modifications to be made to the repository
(i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Install and still be able to generate JSON-LD

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
