### PR TITLE
Add optional pass_target_id argument to

### DIFF
--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -18,15 +18,24 @@ class EntityReferenceConverter {
    *   An array of arguments defined in the mapping.
    *   Expected keys are:
    *     - link_field: The field used to store the URI we will use.
-   *     - pass_target_id: (true/false) If it should return a target ID
-   *       when no term is found.
+   *     - pass_target_id: (true/false) should we return a target ID
+   *       when no term is found?
    *
    * @return mixed
-   *   Either the replaced URI string OR the targeted entity if no URI.
+   *   In order of availability:
+   *     - the replaced URI string,
+   *     - the target entity's label,
+   *     - (if pass_target_id is true) the target entity's ID,
+   *     - or an empty string.
    */
   public static function linkFieldPassthrough($target, array $arguments) {
-    if (is_a($target, 'Drupal\Core\Entity\FieldableEntityInterface') && !empty($target->get($arguments['link_field'])->uri)) {
-      return $target->get($arguments['link_field'])->uri;
+    if (is_a($target, 'Drupal\Core\Entity\FieldableEntityInterface')) {
+      if (empty($target->get($arguments['link_field'])->uri)) {
+        return $target->label();
+      }
+      else {
+        return $target->get($arguments['link_field'])->uri;
+      }
     }
 
     if (is_array($target) && array_key_exists('target_id', $target)) {

--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -18,6 +18,7 @@ class EntityReferenceConverter {
    *   An array of arguments defined in the mapping.
    *   Expected keys are:
    *     - link_field: The field used to store the URI we will use.
+   *     - pass_target_id: (true/false) If it should return a target ID when no term is found.
    *
    * @return mixed
    *   Either the replaced URI string OR the targeted entity if no URI.
@@ -35,9 +36,12 @@ class EntityReferenceConverter {
       elseif ($ent) {
         return $ent->get('name')->value;
       }
+      elseif (array_key_exists('pass_target_id', $arguments) && $arguments['pass_target_id']) {
+        return $target['target_id'];
+      }
     }
-    // We don't have a value to pass, so don't bother converting.
-    return $target;
+    // Nothing worked, so return nothing.
+    return '';
   }
 
 }

--- a/src/EntityReferenceConverter.php
+++ b/src/EntityReferenceConverter.php
@@ -18,7 +18,8 @@ class EntityReferenceConverter {
    *   An array of arguments defined in the mapping.
    *   Expected keys are:
    *     - link_field: The field used to store the URI we will use.
-   *     - pass_target_id: (true/false) If it should return a target ID when no term is found.
+   *     - pass_target_id: (true/false) If it should return a target ID
+   *       when no term is found.
    *
    * @return mixed
    *   Either the replaced URI string OR the targeted entity if no URI.


### PR DESCRIPTION
**GitHub Issue**: https://github.com/asulibraries/islandora-repo/issues/549

# What does this Pull Request do?

Adds an optional 'pass_target_id' parameter to the EntityReferenceConverter::linkFieldPassthrough that allows us to pass through the target ID OR an empty string if it couldn't load the target ID's taxonomy term. This prevents errors from popping up in the watchdog for rest_oai_pmh and JSON-LD when an invalid target shows up.

# What's new?
* Adds an optional 'pass_target_id' parameter to the EntityReferenceConverter::linkFieldPassthrough that allows us to pass through the target ID OR an empty string if it couldn't load the target ID's taxonomy term.
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
(i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

A description of what steps someone could take to:
* Make or reuse a taxonomy with URIs
* Update the RDF mapping to use the linkFieldPassthrough converter, e.g.
```
  field_standard_rights:
    properties:
      - 'dcterms:rights'
    datatype_callback:
      callable: 'Drupal\jsonld\EntityReferenceConverter::linkFieldPassthrough'
      arguments:
        link_field: field_source
```
* Make a node with an entity reference for this field that is invalid. This is easiest to do using `drush php:cli` to load an existing node and update the field, e.g.:
```
$node = \Drupal::entityTypeManager()->getStorage('node')->load(3);
$node->field_standard_rights[] = ['target_id'=> 0];
$node->save();
```
* View the JSON-LD or OAI-PMH endpoint
* Now check your logs and you should see an error complaining about 'target_id'.
* Apply the patch 
* Clear cache
* Reload either the JSON-LD or OAI-PMH feed.
* Check the logs, there shouldn't be any new errors.
* Even further: update your RDF mapping to pass the target_id, e.g.:
```
  field_standard_rights:
    properties:
      - 'dcterms:rights'
    datatype_callback:
      callable: 'Drupal\jsonld\EntityReferenceConverter::linkFieldPassthrough'
      arguments:
        link_field: field_source
        pass_target_id: true
```
* Clear cache and view the item again. Now the invalid target_id will show up as the value for the configured field.

# Interested parties
@Islandora/8-x-committers
