### PR TITLE
Add contrib hal and rdf to composer. Also fix deprecated code.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ["7.4", "8.0", "8.1"]
-        drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
+        drupal-version: ["9.4.x", "9.5.x-dev"]
 
     env:
       DRUPAL_VERSION: ${{ matrix.drupal-version }}

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ["7.4", "8.0", "8.1"]
-        drupal-version: ["9.4.x", "9.5.x-dev"]
+        drupal-version: ["9.4.x", "9.5.x"]
 
     env:
       DRUPAL_VERSION: ${{ matrix.drupal-version }}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         }
     ],
     "require" : {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "drupal/hal": "^1||^2",
+        "drupal/rdf": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",

--- a/jsonld.info.yml
+++ b/jsonld.info.yml
@@ -2,7 +2,7 @@ name: 'JSON-LD'
 type: module
 description: 'Serializes entities to JSON-LD / LDP for the Islandora Project'
 package: Web services
-core_version_requirement: ^9
+core_version_requirement: ^9.4
 dependencies:
   - drupal:serialization
   - hal:hal

--- a/jsonld.info.yml
+++ b/jsonld.info.yml
@@ -4,6 +4,6 @@ description: 'Serializes entities to JSON-LD / LDP for the Islandora Project'
 package: Web services
 core_version_requirement: ^9
 dependencies:
-  - hal
-  - serialization
-  - rdf
+  - drupal:serialization
+  - hal:hal
+  - rdf:rdf

--- a/src/ContextGenerator/JsonldContextGenerator.php
+++ b/src/ContextGenerator/JsonldContextGenerator.php
@@ -333,9 +333,8 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
     // yet for this instance.
     if (empty($this->fieldMappings)) {
       // Cribbed from rdf module's rdf_get_namespaces.
-      foreach (\Drupal::moduleHandler()->getImplementations(self::FIELD_MAPPPINGS_HOOK) as $module) {
-        $function = $module . '_' . self::FIELD_MAPPPINGS_HOOK;
-        foreach ($function() as $field => $mapping) {
+      \Drupal::moduleHandler()->invokeAllWith(self::FIELD_MAPPPINGS_HOOK, function (callable $hook, string $module) {
+        foreach ($hook() as $field => $mapping) {
           if (array_key_exists($field, $this->fieldMappings)) {
             $this->logger->warning(
               t('Tried to map @field_type to @new_type, but @field_type is already mapped to @orig_type.', [
@@ -349,7 +348,7 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
             $this->fieldMappings[$field] = $mapping;
           }
         }
-      }
+      });
     }
     return array_key_exists($field_type, $this->fieldMappings) ? $this->fieldMappings[$field_type] : $default_mapping;
   }

--- a/tests/src/Functional/JsonldContextGeneratorTest.php
+++ b/tests/src/Functional/JsonldContextGeneratorTest.php
@@ -94,7 +94,7 @@ class JsonldContextGeneratorTest extends BrowserTestBase {
     );
     $this->drupalGet($url);
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertEquals($this->drupalGetHeader('Content-Type'), 'application/ld+json', 'Correct JSON-LD mime type was returned');
+    $this->assertEquals($this->getSession()->getResponseHeader('Content-Type'), 'application/ld+json', 'Correct JSON-LD mime type was returned');
   }
 
   /**
@@ -121,7 +121,7 @@ class JsonldContextGeneratorTest extends BrowserTestBase {
     $this->drupalGet($url);
     $this->assertSession()->statusCodeEquals(200);
     $jsonldarray = json_decode($this->getSession()->getPage()->getContent(), TRUE);
-    $this->verbose($jsonldarray);
+    dump($jsonldarray);
     $this->assertEquals($expected, $jsonldarray, "Returned @context matches expected response.");
   }
 

--- a/tests/src/Kernel/JsonldContextGeneratorTest.php
+++ b/tests/src/Kernel/JsonldContextGeneratorTest.php
@@ -17,7 +17,7 @@ class JsonldContextGeneratorTest extends JsonldKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'hal',
     'jsonld',

--- a/tests/src/Kernel/JsonldHookTest.php
+++ b/tests/src/Kernel/JsonldHookTest.php
@@ -13,7 +13,7 @@ class JsonldHookTest extends JsonldKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'hal',
     'jsonld',

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -24,7 +24,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'field',

--- a/tests/src/Kernel/JsonldTestEntityGenerator.php
+++ b/tests/src/Kernel/JsonldTestEntityGenerator.php
@@ -158,7 +158,7 @@ class JsonldTestEntityGenerator {
    *   Error saving the entity.
    */
   public function generateNewEntity(): array {
-    $dt = new \DateTime(NULL, new \DateTimeZone('UTC'));
+    $dt = new \DateTime('now', new \DateTimeZone('UTC'));
     $created = $dt->format("U");
     $created_iso = $dt->format(\DateTime::W3C);
     // Create an entity.


### PR DESCRIPTION
**GitHub Issue**: For a smoother upgrade to Drupal 10, we can start using contributed components now. 

* https://github.com/Islandora/documentation/issues/2235

# What does this Pull Request do?

Makes Upgrade Status a little happier.

# What's new?

* Added composer dependencies the contrib versions of rdf and hal.
* Could this change impact execution of existing code? no it should not.

This mirrors what already happened in #69 on the 3.x branch, but for Drupal 9. 

# How should this be tested?

Install [Upgrade Status](https://www.drupal.org/project/upgrade_status) and it will tell you there are "Deprecated or obsolete core extensions installed". 

With this PR, after a composer update and a cache clear, there shouldn't be. 

# Additional Notes:
Any additional information that you think would be helpful when reviewing this 
PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
