### PR TITLE
3.x requires D10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require" : {
-        "php": ">=7.4",
+        "drupal/core": "^10",
         "drupal/hal": "^1||^2",
         "drupal/rdf": "^2.1"
     },


### PR DESCRIPTION
**GitHub Issue**: (link)

If we make a release for 3.0.0 (which I did but then deleted, sorry!), this branch will get picked up in Drupal 9 because we don't explicitly say it's only compatible with Drupal 10 - until this PR. 

# What does this Pull Request do?

Tells Composer this module requires drupal 10 (on the 3.x branch!)

# What's new?

# How should this be tested?

* do tests pass on 9.5?
* do tests pass on 10?

# Additional Notes:
Any additional information that you think would be helpful when reviewing this 
PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
