### PR TITLE
Update workflows.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -49,12 +49,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: build_dir
 
       - name: Checkout islandora_ci
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: islandora/islandora_ci
           ref: github-actions
@@ -72,7 +72,7 @@ jobs:
           sudo apt-get install -y mysql-client
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/composer-cache
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/build-3.x.yml
+++ b/.github/workflows/build-3.x.yml
@@ -49,12 +49,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: build_dir
 
       - name: Checkout islandora_ci
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: islandora/islandora_ci
           ref: github-actions
@@ -72,7 +72,7 @@ jobs:
           sudo apt-get install -y mysql-client
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/composer-cache
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
**GitHub Issue**: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/


# What does this Pull Request do?

Use non-deprecated Actions in the github Actions.

# What's new?

# How should this be tested?

If github actions completes and doesn't give deprecation warnings, it worked.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this 
PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
