### PR TITLE
Issue #3493364 by priti197: runtime error after installing module

### DIFF
--- a/config/install/jsonld.settings.yml
+++ b/config/install/jsonld.settings.yml
@@ -1,1 +1,2 @@
 remove_jsonld_format: false
+rdf_namespaces: []

--- a/src/Form/JsonLdSettingsForm.php
+++ b/src/Form/JsonLdSettingsForm.php
@@ -50,11 +50,14 @@ class JsonLdSettingsForm extends ConfigFormBase {
     ];
 
     $rdf_namespaces = '';
-    foreach ($config->get('rdf_namespaces') as $namespace) {
-      if (isset($mappings_from_hook[$namespace['prefix']])) {
-        unset($mappings_from_hook[$namespace['prefix']]);
+    $namespaces = $config->get('rdf_namespaces');
+    if(is_array($namespaces) || is_object($namespaces)){
+      foreach ($config->get('rdf_namespaces') as $namespace) {
+        if (isset($mappings_from_hook[$namespace['prefix']])) {
+          unset($mappings_from_hook[$namespace['prefix']]);
+        }
+        $rdf_namespaces .= $namespace['prefix'] . '|' . $namespace['namespace'] . "\n";
       }
-      $rdf_namespaces .= $namespace['prefix'] . '|' . $namespace['namespace'] . "\n";
     }
     $mapping_string = '';
     ksort($mappings_from_hook);

--- a/src/Form/JsonLdSettingsForm.php
+++ b/src/Form/JsonLdSettingsForm.php
@@ -50,14 +50,12 @@ class JsonLdSettingsForm extends ConfigFormBase {
     ];
 
     $rdf_namespaces = '';
-    $namespaces = $config->get('rdf_namespaces');
-    if (is_array($namespaces) || is_object($namespaces)) {
-      foreach ($namespaces as $namespace) {
-        if (isset($mappings_from_hook[$namespace['prefix']])) {
-          unset($mappings_from_hook[$namespace['prefix']]);
-        }
-        $rdf_namespaces .= $namespace['prefix'] . '|' . $namespace['namespace'] . "\n";
+    $namespaces = $config->get('rdf_namespaces') ?? [];
+    foreach ($namespaces as $namespace) {
+      if (isset($mappings_from_hook[$namespace['prefix']])) {
+        unset($mappings_from_hook[$namespace['prefix']]);
       }
+      $rdf_namespaces .= $namespace['prefix'] . '|' . $namespace['namespace'] . "\n";
     }
     $mapping_string = '';
     ksort($mappings_from_hook);

--- a/src/Form/JsonLdSettingsForm.php
+++ b/src/Form/JsonLdSettingsForm.php
@@ -51,8 +51,8 @@ class JsonLdSettingsForm extends ConfigFormBase {
 
     $rdf_namespaces = '';
     $namespaces = $config->get('rdf_namespaces');
-    if(is_array($namespaces) || is_object($namespaces)){
-      foreach ($config->get('rdf_namespaces') as $namespace) {
+    if (is_array($namespaces) || is_object($namespaces)) {
+      foreach ($namespaces as $namespace) {
         if (isset($mappings_from_hook[$namespace['prefix']])) {
           unset($mappings_from_hook[$namespace['prefix']]);
         }


### PR DESCRIPTION
**GitHub Issue**: (link)

https://www.drupal.org/project/jsonld/issues/3493364

# What does this Pull Request do?

Notes from d.o issue:

 I went to the settings page @ /admin/config/search/jsonld, I saw the following runtime error:
```
Warning: foreach() argument must be of type array|object, null given in Drupal\jsonld\Form\JsonLdSettingsForm->buildForm() (line 53 of modules/contrib/jsonld/src/Form/JsonLdSettingsForm.php).
Drupal\jsonld\Form\JsonLdSettingsForm->buildForm()
call_user_func_array() (Line: 536)
Drupal\Core\Form\FormBuilder->retrieveForm() (Line: 283)
Drupal\Core\Form\FormBuilder->buildForm() (Line: 73)
Drupal\Core\Controller\FormController->getContentResult()
call_user_func_array() (Line: 123)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 627)
Drupal\Core\Render\Renderer->executeInRenderContext() (Line: 121)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext() (Line: 97)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 181)
Symfony\Component\HttpKernel\HttpKernel->handleRaw() (Line: 76)
Symfony\Component\HttpKernel\HttpKernel->handle() (Line: 58)
Drupal\Core\StackMiddleware\Session->handle() (Line: 48)
Drupal\Core\StackMiddleware\KernelPreHandle->handle() (Line: 28)
Drupal\Core\StackMiddleware\ContentLength->handle() (Line: 32)
Drupal\big_pipe\StackMiddleware\ContentLength->handle() (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass() (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle() (Line: 50)
Drupal\ban\BanMiddleware->handle() (Line: 48)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle() (Line: 51)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle() (Line: 36)
Drupal\Core\StackMiddleware\AjaxPageState->handle() (Line: 49)
Drupal\remove_http_headers\StackMiddleware\RemoveHttpHeadersMiddleware->handle() (Line: 51)
Drupal\Core\StackMiddleware\StackedHttpKernel->handle() (Line: 704)
Drupal\Core\DrupalKernel->handle() (Line: 19)
```

This PR ensures the config exists before iterating on the config. Most folks in Islandora likely don't come across this as most of our sites are bootstrapped with the proper data.