### PR TITLE
Fix case mismatch

### DIFF
--- a/src/JsonldServiceProvider.php
+++ b/src/JsonldServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Jsonld;
+namespace Drupal\jsonld;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceModifierInterface;


### PR DESCRIPTION
This came up in a CI test https://github.com/mjordan/islandora_workbench_integration/pull/36 causing it to fail for Drupal 11 (and I suspect all code paths loading this service on Drupal 11 will fail)

https://github.com/lehigh-university-libraries/islandora_workbench_integration/actions/runs/14502144250/job/40684079294#step:3:295

```
 Case mismatch between loaded and declared class names: "Drupal\jsonld\JsonldServiceProvider" vs "Drupal\Jsonld\JsonldServiceProvider"
```

@Islandora/committers
