### PR TITLE
Use new lint/test docker image in CI, lint codebase

### DIFF
--- a/.github/workflows/build-3.x.yml
+++ b/.github/workflows/build-3.x.yml
@@ -1,115 +1,37 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the 8.x branch
   push:
     branches: [ 3.x ]
   pull_request:
     branches: [ 3.x ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    continue-on-error: false
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ["8.1", "8.2", "8.3"]
-        drupal-version: ["10.3.x", "10.4.x-dev", "11.0.x"]
-        exclude:
-          - drupal-version: "11.0.x"
-            php-versions: "8.1"
-          - drupal-version: "11.0.x"
-            php-versions: "8.2"
-    env:
-      DRUPAL_VERSION: ${{ matrix.drupal-version }}
-      SCRIPT_DIR: ${{ github.workspace }}/islandora_ci
-      DRUPAL_DIR: /opt/drupal
-      DRUPAL_WEB_ROOT: /opt/drupal/web
-      PHPUNIT_FILE: ${{ github.workspace }}/build_dir/phpunit.xml
-
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: drupal
-        ports:
-          - 3306:3306
-      activemq:
-        image: webcenter/activemq:5.14.3
-        ports:
-          - 8161:8161
-          - 61616:61616
-          - 61613:61613
-
+        php-versions: ["8.3", "8.4"]
+        drupal-version: ["10.5", "10.6", "11.2", "11.3"]
+    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }}
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          path: build_dir
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
-      - name: Checkout islandora_ci
-        uses: actions/checkout@v4
-        with:
-          repository: islandora/islandora_ci
-          ref: github-actions
-          path: islandora_ci
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          tools: composer:v2
-
-      - name: Setup Mysql client
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mysql-client
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
-
-      - name: Setup Drupal
-        run: |
-          mkdir $DRUPAL_DIR
-          $SCRIPT_DIR/travis_setup_drupal.sh
-          cd $DRUPAL_DIR
-          chmod -R u+w web/sites/default
-          mkdir -p web/sites/simpletest/browser_output
-
-      - name: Setup composer paths
-        run: |
-          git -C "$GITHUB_WORKSPACE/build_dir" checkout -b github-testing
-          cd $DRUPAL_DIR
-          composer config repositories.local path "$GITHUB_WORKSPACE/build_dir"
-          composer config minimum-stability dev
-          composer require "drupal/jsonld:dev-github-testing as dev-3.x" --prefer-source -W
-
-      - name: Install modules
-        run: |
-          cd $DRUPAL_DIR/web
-          drush --uri=127.0.0.1:8282 en -y user jsonld
-
-      - name: Copy PHPunit file
-        run: cp $PHPUNIT_FILE $DRUPAL_DIR/web/core/phpunit.xml
-
-      - name: Test scripts
-        run: $SCRIPT_DIR/travis_scripts.sh
-
-        # Unit test config is defined in the module's phpunit.xml file.
       - name: PHPUNIT tests
         run: |
-          cd $DRUPAL_DIR/web/core
-          $DRUPAL_DIR/vendor/bin/phpunit --debug
+          docker run \
+            --rm \
+            --name drupal \
+            --hostname drupal \
+            --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:ro \
+            --env ENABLE_MODULES \
+           ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
+        env:
+          ENABLE_MODULES: jsonld

--- a/jsonld.services.yml
+++ b/jsonld.services.yml
@@ -36,7 +36,7 @@ services:
     arguments: ['jsonld']
   jsonld.contextgenerator:
     class: Drupal\jsonld\ContextGenerator\JsonldContextGenerator
-    arguments: ['@entity_field.manager','@entity_type.bundle.info','@entity_type.manager', '@cache.default', '@logger.channel.jsonld']
+    arguments: ['@entity_field.manager','@entity_type.bundle.info','@entity_type.manager', '@cache.default', '@logger.channel.jsonld', '@module_handler']
   jsonld.normalizer_utils:
     class: Drupal\jsonld\Utils\JsonldNormalizerUtils
     arguments: ['@config.factory', '@language_manager', '@router.route_provider']

--- a/src/ContextGenerator/JsonldContextGenerator.php
+++ b/src/ContextGenerator/JsonldContextGenerator.php
@@ -168,7 +168,7 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
     // rdfmapping object but has no rdf:type.
     if (empty($bundle_rdf_mappings['types'])) {
       $msg = $this->t("Can't generate JSON-LD Context without at least one rdf:type for Entity type @entity_type, Bundle @bundle_name combo.",
-        ['@entity_type' => $entity_type_id, ' @bundle_name' => $bundle]);
+        ['@entity_type' => $entity_type_id, '@bundle_name' => $bundle]);
       $this->logger->warning("@msg",
         [
           '@msg' => $msg,

--- a/src/ContextGenerator/JsonldContextGenerator.php
+++ b/src/ContextGenerator/JsonldContextGenerator.php
@@ -7,8 +7,9 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\rdf\Entity\RdfMapping;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\rdf\RdfMappingInterface;
 use Psr\Log\LoggerInterface;
 
@@ -20,6 +21,8 @@ use Psr\Log\LoggerInterface;
  * @package Drupal\jsonld\ContextGenerator
  */
 class JsonldContextGenerator implements JsonldContextGeneratorInterface {
+
+  use StringTranslationTrait;
 
   /**
    * Constant Naming convention used to prefix name cache bins($cid)
@@ -69,6 +72,13 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
   protected $logger;
 
   /**
+   * Injected Module Handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * Cached field type mappings.
    *
    * @var array
@@ -88,13 +98,16 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
    *   Caching Backend.
    * @param \Psr\Log\LoggerInterface $logger_channel
    *   Our Logging Channel.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
    */
-  public function __construct(EntityFieldManagerInterface $entity_field_manager, EntityTypeBundleInfoInterface $bundle_info, EntityTypeManagerInterface $entity_manager, CacheBackendInterface $cache_backend, LoggerInterface $logger_channel) {
+  public function __construct(EntityFieldManagerInterface $entity_field_manager, EntityTypeBundleInfoInterface $bundle_info, EntityTypeManagerInterface $entity_manager, CacheBackendInterface $cache_backend, LoggerInterface $logger_channel, ModuleHandlerInterface $module_handler) {
     $this->entityFieldManager = $entity_field_manager;
     $this->entityTypeManager = $entity_manager;
     $this->bundleInfo = $bundle_info;
     $this->cache = $cache_backend;
     $this->logger = $logger_channel;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -105,7 +118,7 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
     $cache = $this->cache->get($cid);
     $data = '';
     if (!$cache) {
-      $rdfMapping = RdfMapping::load($ids);
+      $rdfMapping = $this->entityTypeManager->getStorage('rdf_mapping')->load($ids);
       // Our whole chain of exceptions will never happen
       // because RdfMapping:load returns NULL on non existance
       // Which forces me to check for it
@@ -115,7 +128,7 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
         $data = $this->writeCache($rdfMapping, $cid);
       }
       else {
-        $msg = t("Can't generate JSON-LD Context for @ids without RDF Mapping present.",
+        $msg = $this->t("Can't generate JSON-LD Context for @ids without RDF Mapping present.",
           ['@ids' => $ids]);
         $this->logger->warning("@msg",
           [
@@ -154,7 +167,7 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
     // This only generates an Exception if there is an
     // rdfmapping object but has no rdf:type.
     if (empty($bundle_rdf_mappings['types'])) {
-      $msg = t("Can't generate JSON-LD Context without at least one rdf:type for Entity type @entity_type, Bundle @bundle_name combo.",
+      $msg = $this->t("Can't generate JSON-LD Context without at least one rdf:type for Entity type @entity_type, Bundle @bundle_name combo.",
         ['@entity_type' => $entity_type_id, ' @bundle_name' => $bundle]);
       $this->logger->warning("@msg",
         [
@@ -333,11 +346,11 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
     // yet for this instance.
     if (empty($this->fieldMappings)) {
       // Cribbed from rdf module's rdf_get_namespaces.
-      \Drupal::moduleHandler()->invokeAllWith(self::FIELD_MAPPPINGS_HOOK, function (callable $hook, string $module) {
+      $this->moduleHandler->invokeAllWith(self::FIELD_MAPPPINGS_HOOK, function (callable $hook, string $module) {
         foreach ($hook() as $field => $mapping) {
           if (array_key_exists($field, $this->fieldMappings)) {
             $this->logger->warning(
-              t('Tried to map @field_type to @new_type, but @field_type is already mapped to @orig_type.', [
+              $this->t('Tried to map @field_type to @new_type, but @field_type is already mapped to @orig_type.', [
                 '@field_type' => $field,
                 '@new_type' => $mapping['@type'],
                 '@orig_type' => $this->fieldMappings[$field]['@type'],

--- a/src/Controller/JsonldContextController.php
+++ b/src/Controller/JsonldContextController.php
@@ -7,7 +7,6 @@ use Drupal\Core\Cache\CacheableJsonResponse;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\jsonld\ContextGenerator\JsonldContextGeneratorInterface;
-use Drupal\rdf\Entity\RdfMapping;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -75,7 +74,7 @@ class JsonldContextController extends ControllerBase {
       // For now deal with Cache dependencies manually.
       $meta = new CacheableMetadata();
       $meta->setCacheContexts(['user.permissions', 'ip', 'url']);
-      $meta->setCacheTags(RdfMapping::load("$entity_type.$bundle")->getCacheTags());
+      $meta->setCacheTags($this->entityTypeManager()->getStorage('rdf_mapping')->load("$entity_type.$bundle")->getCacheTags());
       $meta->setCacheMaxAge(Cache::PERMANENT);
       $response->addCacheableDependency($meta);
     }

--- a/src/Normalizer/EntityReferenceItemNormalizer.php
+++ b/src/Normalizer/EntityReferenceItemNormalizer.php
@@ -71,7 +71,6 @@ class EntityReferenceItemNormalizer extends FieldItemNormalizer implements UuidR
     // If the parent entity passed in a langcode, unset it before normalizing
     // the target entity. Otherwise, untranslatable fields of the target entity
     // will include the langcode.
-    $langcode = $context['langcode'] ?? NULL;
     unset($context['langcode']);
     // Limiting to uuid makes sure that we only get one child from base entity
     // if not we could end traversing forever since there is no way

--- a/tests/src/Kernel/JsonldContextGeneratorTest.php
+++ b/tests/src/Kernel/JsonldContextGeneratorTest.php
@@ -73,7 +73,8 @@ class JsonldContextGeneratorTest extends JsonldKernelTestBase {
         $this->container->get('entity_type.bundle.info'),
         $this->container->get('entity_type.manager'),
         $this->container->get('cache.default'),
-        $this->container->get('logger.channel.jsonld')
+        $this->container->get('logger.channel.jsonld'),
+        $this->container->get('module_handler')
       );
 
   }
@@ -127,7 +128,7 @@ class JsonldContextGeneratorTest extends JsonldKernelTestBase {
     // This should throw the expected Exception.
     $newEntity = $this->createContentType();
     $rdfMapping = rdf_get_mapping('entity_test', $newEntity->id());
-    $this->theJsonldContextGenerator->getContext('entity_test.' . $newEntity->id());
+    $this->theJsonldContextGenerator->generateContext($rdfMapping);
   }
 
   /**


### PR DESCRIPTION
**GitHub Issue**: Relates to https://github.com/Islandora/islandora/issues/1095 https://github.com/Islandora/islandora/pull/1096

### What does this Pull Request do?

Replace the CI test GitHub Actions to instead of performing a drupal site install in the runner, use a docker image.

Also fixed a bug the tests surfaced for Drupal 10.x https://github.com/Islandora/jsonld/pull/87/commits/4c90dad2e38f8da3c415823fbd6f9fddf6ddd721

that would throw
```
PHPUnit\Framework\Error\Warning thrown while calling __toString on a Drupal\Core\StringTranslation\TranslatableMarkup object in /var/www/drupal/web/core/lib/Drupal/Component/Render/FormattableMarkup.php on line 247: Placeholders must begin with one of the following "@", ":" or "%", invalid placeholder ( @bundle_name) with string: "Can't generate JSON-LD Context without at least one rdf:type for Entity type @entity_type, Bundle @bundle_name combo."

/var/www/drupal/web/core/lib/Drupal/Component/Utility/ToStringTrait.php:20
/var/www/drupal/web/modules/contrib/jsonld/src/ContextGenerator/JsonldContextGenerator.php:176
```

### How should this be tested?

GitHub Actions pass all green
